### PR TITLE
bump kernel to v0.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ ExternalProject_Add(
         GIT_REPOSITORY "https://github.com/delta-incubator/delta-kernel-rs"
         # WARNING: the FFI headers are currently pinned due to the C linkage issue of the c++ headers. Currently, when bumping
         # the kernel version, the produced header in ./src/include/delta_kernel_ffi.hpp should be also bumped, applying the fix
-        GIT_TAG ed2b80b127984481adba8e59879f39b9e5f871d1
+        GIT_TAG v0.2.0
         # Prints the env variables passed to the cargo build to the terminal, useful in debugging because passing them
         # through CMake is an error-prone mess
         CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${RUST_UNSET_ENV_VARS} ${RUST_ENV_VARS} env

--- a/src/functions/delta_scan.cpp
+++ b/src/functions/delta_scan.cpp
@@ -83,7 +83,7 @@ static void visit_callback(ffi::NullableCvoid engine_context, struct ffi::Kernel
     context->metadata.back()->partition_map = std::move(constant_map);
 }
 
-  static void visit_data(void *engine_context, ffi::EngineData* engine_data, const struct ffi::KernelBoolSlice selection_vec) {
+  static void visit_data(void *engine_context, ffi::ExclusiveEngineData* engine_data, const struct ffi::KernelBoolSlice selection_vec) {
     ffi::visit_scan_data(engine_data, selection_vec, engine_context, visit_callback);
 }
 

--- a/src/include/delta_kernel_ffi.hpp
+++ b/src/include/delta_kernel_ffi.hpp
@@ -393,7 +393,7 @@ struct im_an_unused_struct_that_tricks_msvc_into_compilation {
     ExternResult<ArrowFFIData*> field7;
     ExternResult<Handle<SharedScanDataIterator>> field8;
     ExternResult<Handle<SharedScan>> field9;
-    ExternResult<Handle<SharedScan>> field10;
+    ExternResult<Handle<ExclusiveFileReadResultIterator>> field10;
 };
 
 extern "C" {

--- a/src/include/delta_utils.hpp
+++ b/src/include/delta_utils.hpp
@@ -102,11 +102,11 @@ struct TemplatedUniqueKernelPointer : public UniqueKernelPointer<KernelType> {
     };
 };
 
-typedef TemplatedUniqueKernelPointer<ffi::SharedSnapshot, ffi::drop_snapshot> KernelSnapshot;
-typedef TemplatedUniqueKernelPointer<ffi::SharedExternEngine, ffi::drop_engine> KernelExternEngine;
-typedef TemplatedUniqueKernelPointer<ffi::SharedScan, ffi::drop_scan> KernelScan;
-typedef TemplatedUniqueKernelPointer<ffi::SharedGlobalScanState, ffi::drop_global_scan_state> KernelGlobalScanState;
-typedef TemplatedUniqueKernelPointer<ffi::SharedScanDataIterator, ffi::kernel_scan_data_free> KernelScanDataIterator;
+typedef TemplatedUniqueKernelPointer<ffi::SharedSnapshot, ffi::free_snapshot> KernelSnapshot;
+typedef TemplatedUniqueKernelPointer<ffi::SharedExternEngine, ffi::free_engine> KernelExternEngine;
+typedef TemplatedUniqueKernelPointer<ffi::SharedScan, ffi::free_scan> KernelScan;
+typedef TemplatedUniqueKernelPointer<ffi::SharedGlobalScanState, ffi::free_global_scan_state> KernelGlobalScanState;
+typedef TemplatedUniqueKernelPointer<ffi::SharedScanDataIterator, ffi::free_kernel_scan_data> KernelScanDataIterator;
 
 struct KernelUtils {
     static ffi::KernelStringSlice ToDeltaString(const string &str);

--- a/src/include/functions/delta_scan.hpp
+++ b/src/include/functions/delta_scan.hpp
@@ -22,7 +22,7 @@ struct DeltaFileMetaData {
 
     ~DeltaFileMetaData() {
         if (selection_vector.ptr) {
-            ffi::drop_bool_slice(selection_vector);
+            ffi::free_bool_slice(selection_vector);
         }
     }
 

--- a/test/sql/dat/all.test
+++ b/test/sql/dat/all.test
@@ -53,22 +53,22 @@ FROM parquet_scan('${DAT_PATH}/out/reader_tests/generated/basic_append/expected/
 ----
 
 # with_schema_change
-query I rowsort with_checkpoint
+query I rowsort with_schema_change
 SELECT *
 FROM delta_scan('${DAT_PATH}/out/reader_tests/generated/with_schema_change/delta')
 ----
 
-query I rowsort with_checkpoint
+query I rowsort with_schema_change
 SELECT *
 FROM parquet_scan('${DAT_PATH}/out/reader_tests/generated/with_schema_change/expected/latest/**/*.parquet')
 ----
 
-query I rowsort with_checkpoint_count
+query I rowsort with_schema_change_count
 SELECT count(*)
 FROM delta_scan('${DAT_PATH}/out/reader_tests/generated/with_schema_change/delta')
 ----
 
-query I rowsort with_checkpoint_count
+query I rowsort with_schema_change_count
 SELECT count(*)
 FROM parquet_scan('${DAT_PATH}/out/reader_tests/generated/with_schema_change/expected/latest/**/*.parquet')
 ----
@@ -128,11 +128,6 @@ query I rowsort multi_partitioned_2
 SELECT *
 FROM parquet_scan('${DAT_PATH}/out/reader_tests/generated/multi_partitioned_2/expected/latest/**/*.parquet')
 ----
-
-### FAILING DAT TESTS
-
-# TODO fix all of these
-mode skip
 
 # no_replay
 query I rowsort no_replay


### PR DESCRIPTION
Bump kernel to v0.2.0: all DAT tables are now correctly read